### PR TITLE
Add gnome-snapshot to resolute spec ISO in place of cheese

### DIFF
--- a/resolute/spec/spec.sh
+++ b/resolute/spec/spec.sh
@@ -48,7 +48,7 @@ echo "Creating $out"
 echo "Creating base image"
 #livefs-edit $in out/base.iso --action-yaml spec.yaml
 echo "Adding local debs to pool"
-livefs-edit $in out/spec0.iso --add-apt-repository ppa:kramden-team/kramden-test --install-packages guvcview python3-psutil python3-pyudev python3-reportlab python3-requests kramden-device kramden-provision kramden-spec nvme-cli nwipe
+livefs-edit $in out/spec0.iso --add-apt-repository ppa:kramden-team/kramden-test --install-packages guvcview python3-psutil python3-pyudev python3-reportlab python3-requests kramden-device kramden-provision kramden-spec nvme-cli nwipe gnome-snapshot
 livefs-edit out/spec0.iso out/spec1.iso --install-debs debs/{srvadmin*,command*,firefox*}.deb
 rm -f out/spec0.iso
 livefs-edit out/spec1.iso out/spec2.iso --cp $PWD/kramden-spec-iso new/iso/kramden-spec-iso

--- a/resolute/spec/spec2.sh
+++ b/resolute/spec/spec2.sh
@@ -58,7 +58,7 @@ echo "Creating $out"
 echo "Creating base image"
 #livefs-edit $in out/base.iso --action-yaml spec.yaml
 echo "Adding local debs to pool"
-livefs-edit $in out/spec0.iso --add-apt-repository ppa:kramden-team/kramden-test --install-packages git guvcview python3-psutil python3-pyudev python3-reportlab python3-requests kramden-device kramden-provision kramden-spec nvme-cli nwipe
+livefs-edit $in out/spec0.iso --add-apt-repository ppa:kramden-team/kramden-test --install-packages git guvcview python3-psutil python3-pyudev python3-reportlab python3-requests kramden-device kramden-provision kramden-spec nvme-cli nwipe gnome-snapshot
 livefs-edit out/spec0.iso out/spec1.iso --install-debs debs/{srvadmin*,command*,firefox*}.deb
 rm -f out/spec0.iso
 livefs-edit out/spec1.iso out/spec2.iso --cp $PWD/kramden-spec-iso new/iso/kramden-spec-iso


### PR DESCRIPTION
## Summary

- `cheese` was dropped from `resolute/spec/spec2.sh` (and `spec.sh`) in #4 since Ubuntu removed the package starting with resolute.
- Adds `gnome-snapshot` in its place — the GNOME webcam/photo-booth app that replaced cheese, confirmed available in resolute (50.0-0ubuntu1) via packages.ubuntu.com.

## Test plan

- [ ] Trigger the "Build Kramden Spec ISO" workflow on this branch and confirm it still produces a non-empty `kramden-spec-iso` artifact with `gnome-snapshot` installed instead of `cheese`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LHmgeaGYDZoUigm98BPGK9)_