### PR TITLE
Don't let a missing kramden-seeded.service hang noble autoinstall

### DIFF
--- a/noble/autoinstall.yaml.in
+++ b/noble/autoinstall.yaml.in
@@ -123,6 +123,6 @@ late-commands:
 - 'chmod 644 /target/etc/landscape/client.conf'
 - 'echo kernel.apparmor_restrict_unprivileged_unconfined=0 > /target/etc/sysctl.d/99-kramden-local.conf'
 - 'echo kernel.apparmor_restrict_unprivileged_userns=0 >> /target/etc/sysctl.d/99-kramden-local.conf'
-- curtin in-target --target=/target -- /usr/bin/systemctl enable kramden-seeded.service
+- curtin in-target --target=/target -- bash -c 'systemctl enable kramden-seeded.service || true'
 - '/sbin/poweroff'
 version: 1

--- a/noble/kramden.yaml
+++ b/noble/kramden.yaml
@@ -1,6 +1,9 @@
 - name: add-cmdline-arg
   arg: autoinstall
   persist: false
+- name: add-cmdline-arg
+  arg: console=ttyS0,115200n8
+  persist: false
 - name: add-apt-repository
   repo: ppa:kramden-team/kramden
 - name: add-packages-to-pool


### PR DESCRIPTION
## Summary

- Ports PR #6's fix (originally for `resolute`) to `noble`: `noble/autoinstall.yaml.in` had the identical unguarded `curtin in-target --target=/target -- /usr/bin/systemctl enable kramden-seeded.service` late-command. Since curtin's `late-commands` aborts on the first failing command and `/sbin/poweroff` is the last line of that list, a missing/failed `kramden-seeded.service` unit would hang the QEMU autoinstall indefinitely on noble too.
- Wrap the call in `bash -c '... || true'` so a missing unit can't block the rest of the install from completing.
- Add `console=ttyS0,115200n8` to `noble/kramden.yaml`'s boot cmdline so future hangs actually surface boot/systemd output in CI logs (`autoinstall.sh` already runs QEMU with `-nographic`, which multiplexes ttyS0 to stdout).

## Test plan

- [ ] Trigger the "Build ISO and Disk Image" workflow on this branch and confirm the QEMU autoinstall step completes (reaches poweroff) instead of hanging indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)